### PR TITLE
Add pyflakes and pycodestyle as dependencies

### DIFF
--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -41,7 +41,7 @@ def find_pep8_violations():
     return local(
         "git ls-files -z | "
         "grep -PZz '\.py$' | "
-        "xargs -0 pep8"
+        "xargs -0 pycodestyle"
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='fab-polish',
       license='MIT',
       packages=['fabpolish'],
       install_requires=[
-          'fabric3',
+          'fabric3', 'pyflakes', 'pycodestyle'
       ],
       zip_safe=False)


### PR DESCRIPTION
What?
- Add `pyflakes` and `pycodestyle` to dependencies
- Update pep8 command to `pycodestyle`, since name pep8 has been deprecated.